### PR TITLE
Rename RUNPOD install article to a URL-safe filename and fix content

### DIFF
--- a/thai-01-how-to-install-runpod-virtual-machine.md
+++ b/thai-01-how-to-install-runpod-virtual-machine.md
@@ -4,7 +4,7 @@
 พื้นที่นี้ใช้เก็บรวบรวมความรู้ที่ผมได้เรียนรู้และนำมารวมกัน  
 เนื่องจากผมไม่มีคอมพิวเตอร์สเปคแรง จึงใช้บริการ **Cloud Service** เป็นหลัก เช่น [runpod.io](https://runpod.io?ref=c0v5p0ys)  
 
-[![Watch the video](https://img.youtube.com/vi/KvZRuwcZ3Is/0.jpg)](https://www.youtube.com/watch?v=KvZRuwcZ3Is)
+[![Watch the video](https://img.youtube.com/vi/KvZRuwcZ3Is/maxresdefault.jpg)](https://www.youtube.com/watch?v=KvZRuwcZ3Is)
 
 ## การสมัครใช้งาน Runpod.io  
 การใช้ Runpod จะคิดค่าบริการตามทรัพยากรที่ใช้งานต่อชั่วโมง  
@@ -39,7 +39,7 @@
 ให้มองหาเครื่องที่มีสเปค:  
 ✅ **VRAM:** 20GB ขึ้นไป  
 ✅ **RAM:** 60GB ขึ้นไป  
-✅ **ราคา:** $0.5 - $0.2 USD ต่อชั่วโมง  
+✅ **ราคา:** $0.2 - $0.5 USD ต่อชั่วโมง  
 
 **ระดับความเร็ว (Speed Categories):**  
 - **Low, Medium, High** → ความเร็วในการดาวน์โหลดไฟล์  


### PR DESCRIPTION
## Summary
- Renamed `(Thai) #1 How to install RUNPOD for Virtual machine.md` to `thai-01-how-to-install-runpod-virtual-machine.md` so the GitHub URL no longer needs percent-encoding for spaces/parentheses/`#`. No other file referenced the old filename, so this is a clean rename.
- Switched the YouTube "Watch the video" thumbnail from `0.jpg` to `maxresdefault.jpg` (same video ID `KvZRuwcZ3Is`).
- Fixed a reversed price range typo: `$0.5 - $0.2 USD` → `$0.2 - $0.5 USD`.

## Test plan
- [x] Confirmed via repo-wide search that no other file linked to the old filename before renaming.
- [ ] Manually confirm the YouTube thumbnail now renders on the GitHub-hosted markdown page (could not verify from this environment — outbound access to youtube.com is blocked by network policy).


---
_Generated by [Claude Code](https://claude.ai/code/session_018BP4VFMjDt2E4TijGiQj6W)_